### PR TITLE
Adds code documentation to the public members of the code

### DIFF
--- a/WebIOPiClient/GPIOFunctions.cs
+++ b/WebIOPiClient/GPIOFunctions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace WebIOPiClient
+﻿namespace WebIOPiClient
 {
     public enum GPIOFunctions
     {

--- a/WebIOPiClient/HttpEndpoint.cs
+++ b/WebIOPiClient/HttpEndpoint.cs
@@ -17,6 +17,10 @@ namespace WebIOPiClient
             _client.DefaultRequestHeaders.Add("Authorization", GetAuthToken(username, password));
         }
 
+        /// <summary>
+        /// Gets the function type of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
         public async Task<GPIOFunctions> GetGPIOFunction(int gpioNumber)
         {
             var response = await _client.GetAsync(GetFullUrl($"/GPIO/{gpioNumber}/function"));
@@ -24,6 +28,11 @@ namespace WebIOPiClient
             return GetFunctionFromString(await response.Content.ReadAsStringAsync());
         }
 
+        /// <summary>
+        /// Sets the function type of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        /// <param name="function">   Function type </param>
         public async Task<GPIOFunctions> SetGPIOFunction(int gpioNumber, GPIOFunctions function)
         {
             var response = await _client.PostAsync(GetFullUrl($"/GPIO/{gpioNumber}/function/{GetStringFromFunction(function)}"), null);
@@ -31,6 +40,10 @@ namespace WebIOPiClient
             return GetFunctionFromString(await response.Content.ReadAsStringAsync());
         }
 
+        /// <summary>
+        /// Gets the value of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
         public async Task<int> GetGPIOValue(int gpioNumber)
         {
             var response = await _client.GetAsync(GetFullUrl($"/GPIO/{gpioNumber}/value"));
@@ -38,6 +51,11 @@ namespace WebIOPiClient
             return int.Parse(await response.Content.ReadAsStringAsync());
         }
 
+        /// <summary>
+        /// Sets the value of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        /// <param name="value">      Value to set to </param>
         public async Task<int> SetGPIOValue(int gpioNumber, int value)
         {
             var response = await _client.PostAsync(GetFullUrl($"/GPIO/{gpioNumber}/value/{value}"), null);
@@ -45,6 +63,10 @@ namespace WebIOPiClient
             return int.Parse(await response.Content.ReadAsStringAsync());
         }
 
+        /// <summary>
+        /// Sends a single pulse to the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
         public async Task<int> OutputSinglePulse(int gpioNumber)
         {
             var response = await _client.PostAsync(GetFullUrl($"/GPIO/{gpioNumber}/pulse/"), null);
@@ -52,16 +74,15 @@ namespace WebIOPiClient
             return int.Parse(await response.Content.ReadAsStringAsync());
         }
 
+        /// <summary>
+        /// Runs the specified macro
+        /// </summary>
+        /// <param name="macroName"> Macro Name </param>
         public async Task<string> RunMacro(string macroName)
         {
             var response = await _client.PostAsync(GetFullUrl($"/macros/{macroName}"), null);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();
-        }
-
-        private string GetFullUrl(string route)
-        {
-            return _deviceEndpointUrl + route;
         }
 
         private static string GetAuthToken(string user, string pass)
@@ -75,10 +96,13 @@ namespace WebIOPiClient
             {
                 case "in":
                     return GPIOFunctions.In;
+
                 case "out":
                     return GPIOFunctions.Out;
+
                 case "pwm":
                     return GPIOFunctions.PWM;
+
                 default:
                     return GPIOFunctions.Unknown;
             }
@@ -90,18 +114,31 @@ namespace WebIOPiClient
             {
                 case GPIOFunctions.In:
                     return "in";
+
                 case GPIOFunctions.Out:
                     return "out";
+
                 case GPIOFunctions.PWM:
                     return "pwm";
+
                 default:
                     throw new ArgumentException($"Unknown GPIOFunctions enum member '{value}'");
             }
         }
 
+        private string GetFullUrl(string route)
+        {
+            return _deviceEndpointUrl + route;
+        }
+
         #region IDisposable Support
 
         private bool _disposedValue;
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
 
         private void Dispose(bool disposing)
         {
@@ -113,10 +150,6 @@ namespace WebIOPiClient
             _disposedValue = true;
         }
 
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-        #endregion
+        #endregion IDisposable Support
     }
 }

--- a/WebIOPiClient/IEndpoint.cs
+++ b/WebIOPiClient/IEndpoint.cs
@@ -5,11 +5,43 @@ namespace WebIOPiClient
 {
     public interface IEndpoint : IDisposable
     {
+        /// <summary>
+        /// Gets the function type of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
         Task<GPIOFunctions> GetGPIOFunction(int gpioNumber);
-        Task<int> GetGPIOValue(int gpioNumber);
-        Task<int> OutputSinglePulse(int gpioNumber);
+
+        /// <summary>
+        /// Sets the function type of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        /// <param name="function">   Function type </param>
         Task<GPIOFunctions> SetGPIOFunction(int gpioNumber, GPIOFunctions function);
+
+        /// <summary>
+        /// Gets the value of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        Task<int> GetGPIOValue(int gpioNumber);
+
+        /// <summary>
+        /// Sets the value of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        /// <param name="value">      Value to set to </param>
         Task<int> SetGPIOValue(int gpioNumber, int value);
+
+        /// <summary>
+        /// Sends a single pulse to the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        Task<int> OutputSinglePulse(int gpioNumber);
+
+        /// <summary>
+        /// Runs the specified macro
+        /// </summary>
+        /// <param name="macroName"> Macro Name </param>
         Task<string> RunMacro(string macroName);
+
     }
 }

--- a/WebIOPiClient/MockEndpoint.cs
+++ b/WebIOPiClient/MockEndpoint.cs
@@ -6,14 +6,6 @@ namespace WebIOPiClient
 {
     public sealed class MockEndpoint : IEndpoint
     {
-        private class GPIO
-        {
-            public int PinNumber { get; set; }
-            public int Value { get; set; }
-            public GPIOFunctions Function { get; set; }
-        }
-
-
         private List<GPIO> _list;
 
         public MockEndpoint()
@@ -30,37 +22,72 @@ namespace WebIOPiClient
             _list = null;
         }
 
+        /// <summary>
+        /// Gets the function type of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
         public Task<GPIOFunctions> GetGPIOFunction(int gpioNumber)
         {
             return Task.FromResult(_list.Single(p => p.PinNumber == gpioNumber).Function);//.Result;
         }
 
+        /// <summary>
+        /// Gets the value of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
         public Task<int> GetGPIOValue(int gpioNumber)
         {
             return Task.FromResult(_list.Single(p => p.PinNumber == gpioNumber).Value);
         }
 
+        /// <summary>
+        /// Sends a single pulse to the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
         public Task<int> OutputSinglePulse(int gpioNumber)
         {
             // not actually pulsing a fake device, just return pin's value.
             return GetGPIOValue(gpioNumber);
         }
 
+        /// <summary>
+        /// Runs the specified macro
+        /// </summary>
+        /// <param name="macroName"> Macro Name </param>
+        public Task<string> RunMacro(string macroName)
+        {
+            return Task.FromResult("macro run");
+        }
+
+        /// <summary>
+        /// Sets the function type of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        /// <param name="function">   Function type </param>
         public Task<GPIOFunctions> SetGPIOFunction(int gpioNumber, GPIOFunctions function)
         {
             _list.Single(p => p.PinNumber == gpioNumber).Function = function;
             return Task.FromResult(_list.Single(p => p.PinNumber == gpioNumber).Function);
         }
 
+        /// <summary>
+        /// Sets the value of the specified pin
+        /// </summary>
+        /// <param name="gpioNumber"> GPIO Pin Number </param>
+        /// <param name="value">      Value to set to </param>
         public Task<int> SetGPIOValue(int gpioNumber, int value)
         {
             _list.Single(p => p.PinNumber == gpioNumber).Value = value;
             return Task.FromResult(_list.Single(p => p.PinNumber == gpioNumber).Value);
         }
 
-        public Task<string> RunMacro(string macroName)
+        private class GPIO
         {
-            return Task.FromResult("macro run");
+            public GPIOFunctions Function { get; set; }
+
+            public int PinNumber { get; set; }
+
+            public int Value { get; set; }
         }
     }
 }


### PR DESCRIPTION
Since this is plain .Net there is no current support of <inheritdoc/>, so it was copied around unfortunately.
In addition to that some minor formatting fixes to align the member order of the interface and the main implementation.